### PR TITLE
adding --inspect

### DIFF
--- a/packages/ext-webpack-plugin/dist/pluginUtil.js
+++ b/packages/ext-webpack-plugin/dist/pluginUtil.js
@@ -659,7 +659,7 @@ function runScript(scriptPath, callback) {
 
 
   var invoked = false;
-  var process = childProcess.fork(scriptPath); // listen for errors as they may prevent the exit event from firing
+  var process = childProcess.fork(scriptPath, [], { execArgv : ['--inspect=0'] }); // listen for errors as they may prevent the exit event from firing
 
   process.on('error', function (err) {
     if (invoked) return;

--- a/packages/ext-webpack-plugin/src/pluginUtil.js
+++ b/packages/ext-webpack-plugin/src/pluginUtil.js
@@ -510,7 +510,7 @@ function runScript(scriptPath, callback) {
   var childProcess = require('child_process');
   // keep track of whether callback has been invoked to prevent multiple invocations
   var invoked = false;
-  var process = childProcess.fork(scriptPath);
+  var process = childProcess.fork(scriptPath, [], { execArgv : ['--inspect=0'] });
   // listen for errors as they may prevent the exit event from firing
   process.on('error', function (err) {
     if (invoked) return;


### PR DESCRIPTION
Allow for running web dev server in vs code. 

In order for this to work the child process needs to allow inspection. Otherwise it `exit code 12` is thrown on the child process. 

```
{
  // Use IntelliSense to learn about possible attributes.
  // Hover to view descriptions of existing attributes.
  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
  "version": "0.2.0",
  "configurations": [
    {
      "type": "node",
      "request": "launch",
      "name": "Debug App",
      "program": "${workspaceFolder}/node_modules/webpack-dev-server/bin/webpack-dev-server.js",
      "args": [
        "--env.browser=false",
        "--env.enviroment=development",
        "--env.verbose=yes",
        "--hot",
        "--inline",
        "--client-log-level=trace",
        "--config",
        "./webpack.config.js"
      ],
      "env": {
        "environment": "development",
        "NODE_ENV": "development"
      }
    },
    {
      "type" : "chrome",
      "request" : "launch",
      "name" : "Launch Chrome",
      "url" : "http://localhost:1962",
      "webRoot" : "${workspaceFolder}" 
    }
  ]
}
```