### PR TITLE
OTOOLS-122: Add _runPendingActivations to ext-webpack-plugin for npm 12 compatibility

### DIFF
--- a/packages/ext-webpack-plugin/dist/pluginUtil.js
+++ b/packages/ext-webpack-plugin/dist/pluginUtil.js
@@ -28,7 +28,30 @@ function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key i
 function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == typeof i ? i : String(i); }
 function _toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
 //**********
+function _runPendingActivations() {
+  var fs = require('fs');
+  var path = require('path');
+  var spawnSync = require('child_process').spawnSync;
+  var senchaDir = path.resolve(process.cwd(), 'node_modules/@sencha');
+  if (!fs.existsSync(senchaDir)) return;
+  var isWin = /^win/.test(process.platform);
+  fs.readdirSync(senchaDir).forEach(function(pkg) {
+    var activatePath = path.join(senchaDir, pkg, 'activate.js');
+    if (fs.existsSync(activatePath)) {
+      var result = spawnSync(process.execPath, [activatePath], {
+        cwd: path.join(senchaDir, pkg),
+        stdio: 'inherit',
+        shell: isWin
+      });
+      if (result.error) {
+        console.error('[ext-webpack-plugin] Activation error for @sencha/' + pkg + ':', result.error.message);
+      }
+    }
+  });
+}
+
 function _constructor(initialOptions) {
+  _runPendingActivations();
   const fs = require('fs');
   var vars = {};
   var options = {};

--- a/packages/ext-webpack-plugin/src/pluginUtil.js
+++ b/packages/ext-webpack-plugin/src/pluginUtil.js
@@ -1,6 +1,32 @@
 
+// npm 12 compatibility: runs any pending activate.js scripts in @sencha packages
+// before the first compilation. activate.js self-deletes after running so this
+// is a one-shot check per install.
+function _runPendingActivations() {
+  const fs = require('fs');
+  const path = require('path');
+  const { spawnSync } = require('child_process');
+  const senchaDir = path.resolve(process.cwd(), 'node_modules/@sencha');
+  if (!fs.existsSync(senchaDir)) return;
+  const isWin = /^win/.test(process.platform);
+  fs.readdirSync(senchaDir).forEach(pkg => {
+    const activatePath = path.join(senchaDir, pkg, 'activate.js');
+    if (fs.existsSync(activatePath)) {
+      const result = spawnSync(process.execPath, [activatePath], {
+        cwd: path.join(senchaDir, pkg),
+        stdio: 'inherit',
+        shell: isWin
+      });
+      if (result.error) {
+        console.error(`[ext-webpack-plugin] Activation error for @sencha/${pkg}:`, result.error.message);
+      }
+    }
+  });
+}
+
 //**********
 export function _constructor(initialOptions) {
+  _runPendingActivations()
   const fs = require('fs')
   var vars = {}
   var options = {}


### PR DESCRIPTION
## Findings

npm 12 dropped support for `install` lifecycle scripts in published packages. `@sencha/ext-*` packages relied on `scripts.install: "node activate.js"` to activate the Ext JS license on first use. That hook is now silently skipped, leaving the package non-functional after install.

## Root cause

`ext-webpack-plugin` had no mechanism to trigger `activate.js` once the lifecycle script was removed.

## Fix

Added `_runPendingActivations()` to `pluginUtil.js` (both `src/` and compiled `dist/`), called at the top of `_constructor()` before the first webpack compilation.

The function scans `node_modules/@sencha/*/activate.js` and runs each found script synchronously via `spawnSync`. `activate.js` self-deletes after running (existing behaviour), so `existsSync` makes this a true one-shot check per install.

## Related PRs

- `extjs/SenchaDeploy` [#590](https://github.com/extjs/SenchaDeploy/pull/590) — removes `scripts.install` from published ext/cmd packages; converts `activate.js` to `spawnSync`
- `sencha/ext-gen` — removes `scripts.install` from `@sencha/ext-gen`; lazy `install.js` on first CLI invocation